### PR TITLE
Remove redundant steps

### DIFF
--- a/10-Developer-Guide/17-Child-Forms-and-KeepViewVisibleAfterExit/04-Exercise-Cached-KeepViewVisibleAfterExit/index.md
+++ b/10-Developer-Guide/17-Child-Forms-and-KeepViewVisibleAfterExit/04-Exercise-Cached-KeepViewVisibleAfterExit/index.md
@@ -4,6 +4,3 @@
 2.  Refactor the click event of the **Products button** to a method in the controller.   
 3.  Change the call to use Cached.
 4. In **ShowProducts** at the **Run** method clear the where.
-4. Add **ShowCategories** to the **ApplicationMdi**.
-5. Build and Test 
-


### PR DESCRIPTION
The last two steps are already at the end of the previous exercise - Exercise KeepViewVisibleAfterExit.